### PR TITLE
Fix apple pay button when DW disabled

### DIFF
--- a/assets/js/square-payments.js
+++ b/assets/js/square-payments.js
@@ -280,12 +280,14 @@ jQuery(document).ready(function($) {
 				// Using separate 'try' blocks to give both methods a chance to load.
 				try {
 					// Apple Pay.
+					this.applePayButton.show();
 					this.applePay = await this.initializeApplePay(this.squarePayments);
 				} catch (error) {
 					this.paymentError(error, false);
 				}
 				try {
 					// Google Pay.
+					this.googlePayButton.show();
 					this.googlePay = await this.initializeGooglePay(this.squarePayments);
 				} catch (error) {
 					this.paymentError(error, false);
@@ -313,7 +315,7 @@ jQuery(document).ready(function($) {
 
 		/**
 		 * @function initializeGooglePay
-		 * Initializes the Apple Pay object for Square payments.
+		 * Initializes the Google Pay object for Square payments.
 		 * @param  {object} payments
 		 */
 		this.initializeGooglePay = async function (payments) {

--- a/payment_methods/SquareOnsite/templates/squareEmbeddedForm.template.php
+++ b/payment_methods/SquareOnsite/templates/squareEmbeddedForm.template.php
@@ -11,9 +11,9 @@
 ?>
 <div id="eea-square-pm-form-div">
     <!-- Apple Pay button -->
-    <div id="apple-pay-button" class="apple-pay-button"></div>
+    <div id="apple-pay-button" class="apple-pay-button" style="display:none;"></div>
     <!-- Google Pay button -->
-    <div id="eea-square-pm-google-pay" class="google-pay-button"></div>
+    <div id="eea-square-pm-google-pay" class="google-pay-button" style="display:none;"></div>
 
     <div id="sq-card-se"></div>
     <input type="submit" id="eea-square-pay-button" class="button-credit-card" value="<?php esc_html_e('Pay', 'event_espresso');?>" style="display: none;">


### PR DESCRIPTION
Resolves #9 

This fixes the digital wallet, when the Apple Pay button was shown in Safari while the DW was disabled in the settings.