### PR TITLE
Enhance param validation

### DIFF
--- a/modules/EED_SquareOnsite.module.php
+++ b/modules/EED_SquareOnsite.module.php
@@ -94,9 +94,13 @@ class EED_SquareOnsite extends EED_Module
         $orderId      = $transaction->get_extra_meta('order_id', true, false);
         $orderVersion = $transaction->get_extra_meta('order_version', true, false);
         $pmSettings   = $paymentMethod->settings_array();
-        if ($orderId && isset($pmSettings[ Domain::META_KEY_ACCESS_TOKEN ])) {
+        $access_token = EED_SquareOnsiteOAuth::decryptString(
+            $pmSettings[ Domain::META_KEY_ACCESS_TOKEN ],
+            $pmSettings['debug_mode']
+        );
+        if ($orderId && $access_token && isset($pmSettings[ Domain::META_KEY_ACCESS_TOKEN ])) {
             $SquareApi = new SquareApi(
-                $pmSettings[ Domain::META_KEY_ACCESS_TOKEN ],
+                $access_token,
                 $pmSettings[ Domain::META_KEY_APPLICATION_ID ],
                 $pmSettings[ Domain::META_KEY_USE_DIGITAL_WALLET ],
                 $pmSettings['debug_mode'],

--- a/modules/EED_SquareOnsite.module.php
+++ b/modules/EED_SquareOnsite.module.php
@@ -94,11 +94,13 @@ class EED_SquareOnsite extends EED_Module
         $orderId      = $transaction->get_extra_meta('order_id', true, false);
         $orderVersion = $transaction->get_extra_meta('order_version', true, false);
         $pmSettings   = $paymentMethod->settings_array();
-        $access_token = EED_SquareOnsiteOAuth::decryptString(
-            $pmSettings[ Domain::META_KEY_ACCESS_TOKEN ],
-            $pmSettings['debug_mode']
-        );
-        if ($orderId && $access_token && isset($pmSettings[ Domain::META_KEY_ACCESS_TOKEN ])) {
+        $access_token = ! empty($pmSettings[ Domain::META_KEY_ACCESS_TOKEN ])
+            ? EED_SquareOnsiteOAuth::decryptString(
+                $pmSettings[ Domain::META_KEY_ACCESS_TOKEN ],
+                $pmSettings['debug_mode']
+            )
+            : false;
+        if ($orderId && $access_token) {
             $SquareApi = new SquareApi(
                 $access_token,
                 $pmSettings[ Domain::META_KEY_APPLICATION_ID ],

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -604,8 +604,9 @@ class EED_SquareOnsiteOAuth extends EED_Module
      * @return boolean
      * @throws EE_Error
      * @throws ReflectionException
+     * @throws Exception
      */
-    public static function checkAndRefreshToken($squarePm)
+    public static function checkAndRefreshToken($squarePm): bool
     {
         // Check if OAuthed first.
         if (EED_SquareOnsiteOAuth::isAuthenticated($squarePm)) {
@@ -653,14 +654,18 @@ class EED_SquareOnsiteOAuth extends EED_Module
         if (! $squarePm) {
             return false;
         }
-        $squareData = $squarePm->get_extra_meta(Domain::META_KEY_SQUARE_DATA, true);
-        $accessToken = EED_SquareOnsiteOAuth::decryptString(
-            $squarePm->get_extra_meta(Domain::META_KEY_ACCESS_TOKEN, true, ''),
-            $squarePm->debug_mode()
-        );
+        // access token ok ?
+        $access_token = $squarePm->get_extra_meta(Domain::META_KEY_ACCESS_TOKEN, true, '');
+        $square_data  = $squarePm->get_extra_meta(Domain::META_KEY_SQUARE_DATA, true);
+        if (! $access_token || ! $square_data) {
+            return false;
+        }
+
+        // now check if we can decrypt the token etc.
+        $accessToken = EED_SquareOnsiteOAuth::decryptString($access_token, $squarePm->debug_mode());
         if (
-            isset($squareData[ Domain::META_KEY_USING_OAUTH ])
-            && $squareData[ Domain::META_KEY_USING_OAUTH ]
+            isset($square_data[ Domain::META_KEY_USING_OAUTH ])
+            && $square_data[ Domain::META_KEY_USING_OAUTH ]
             && ! empty($accessToken)
         ) {
             return true;

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -106,8 +106,8 @@ class EED_SquareOnsiteOAuth extends EED_Module
             || empty($_GET[ Domain::META_KEY_EXPIRES_AT ])
             || empty($_GET[ Domain::META_KEY_ACCESS_TOKEN ])
             || empty($_GET[ Domain::META_KEY_MERCHANT_ID ])
-            || empty($_GET[ Domain::META_KEY_REFRESH_TOKEN ])
             || empty($_GET[ Domain::META_KEY_APPLICATION_ID ])
+            || ! isset($_GET[ Domain::META_KEY_REFRESH_TOKEN ])
             || ! isset($_GET[ Domain::META_KEY_LIVE_MODE ])
         ) {
             // Missing parameters for some reason. Can't proceed.

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -698,9 +698,9 @@ class EED_SquareOnsiteOAuth extends EED_Module
      *
      * @param string $text
      * @param bool   $sandbox_mode
-     * @return string|null
+     * @return string
      */
-    public static function decryptString(string $text, bool $sandbox_mode): ?string
+    public static function decryptString(string $text, bool $sandbox_mode): string
     {
         // Are we even getting something ?
         if (! $text) {
@@ -711,7 +711,8 @@ class EED_SquareOnsiteOAuth extends EED_Module
         $key_identifier = $sandbox_mode
             ? SquareEncryptionKeyManager::SANDBOX_ENCRYPTION_KEY_ID
             : SquareEncryptionKeyManager::PRODUCTION_ENCRYPTION_KEY_ID;
-        return $encryptor->decrypt($text, $key_identifier);
+        $decrypted = $encryptor->decrypt($text, $key_identifier);
+        return $decrypted ?? '';
     }
 
 

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -102,15 +102,13 @@ class EED_SquareOnsiteOAuth extends EED_Module
             EED_SquareOnsiteOAuth::closeOauthWindow(esc_html__('Nonce fail!', 'event_espresso'));
         }
         if (
-            ! isset(
-                $_GET['square_slug'],
-                $_GET[ Domain::META_KEY_EXPIRES_AT ],
-                $_GET[ Domain::META_KEY_ACCESS_TOKEN ],
-                $_GET[ Domain::META_KEY_MERCHANT_ID ],
-                $_GET[ Domain::META_KEY_REFRESH_TOKEN ],
-                $_GET[ Domain::META_KEY_APPLICATION_ID ],
-                $_GET[ Domain::META_KEY_LIVE_MODE ]
-            )
+            empty($_GET['square_slug'])
+            || empty($_GET[ Domain::META_KEY_EXPIRES_AT ])
+            || empty($_GET[ Domain::META_KEY_ACCESS_TOKEN ])
+            || empty($_GET[ Domain::META_KEY_MERCHANT_ID ])
+            || empty($_GET[ Domain::META_KEY_REFRESH_TOKEN ])
+            || empty($_GET[ Domain::META_KEY_APPLICATION_ID ])
+            || empty($_GET[ Domain::META_KEY_LIVE_MODE ])
         ) {
             // Missing parameters for some reason. Can't proceed.
             EED_SquareOnsiteOAuth::closeOauthWindow(esc_html__('Missing OAuth required parameters.', 'event_espresso'));
@@ -463,16 +461,14 @@ class EED_SquareOnsiteOAuth extends EED_Module
 
             if (
                 ! wp_verify_nonce($responseBody->nonce, 'eea_square_refresh_access_token')
-                || ! isset(
-                    $responseBody->expires_at,
-                    $responseBody->application_id,
-                    $responseBody->access_token,
-                    $responseBody->refresh_token,
-                    $responseBody->merchant_id
-                )
+                || empty($responseBody->expires_at)
+                || empty($responseBody->application_id)
+                || empty($responseBody->access_token)
+                || empty($responseBody->refresh_token)
+                || empty($responseBody->merchant_id)
             ) {
                 // This is an error.
-                $errMsg = esc_html__('Could not get the refresh token.', 'event_espresso');
+                $errMsg = esc_html__('Could not get the refresh token and/or other parameters.', 'event_espresso');
                 EED_SquareOnsiteOAuth::errorLogAndExit($squarePm, $errMsg, false);
             }
 
@@ -681,10 +677,10 @@ class EED_SquareOnsiteOAuth extends EED_Module
      * @return string|null
      * @throws Exception
      */
-    public static function encryptString($text = '', bool $sandbox_mode): ?string
+    public static function encryptString(string $text, bool $sandbox_mode): ?string
     {
         // We sure we are getting something ?
-        if (! $text || ! is_string($text)) {
+        if (! $text) {
             return $text;
         }
         // Do encrypt.
@@ -704,10 +700,10 @@ class EED_SquareOnsiteOAuth extends EED_Module
      * @param bool   $sandbox_mode
      * @return string|null
      */
-    public static function decryptString($text = '', bool $sandbox_mode): ?string
+    public static function decryptString(string $text, bool $sandbox_mode): ?string
     {
         // Are we even getting something ?
-        if (! $text || ! is_string($text)) {
+        if (! $text) {
             return $text;
         }
         // Try decrypting.

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -177,7 +177,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
         if (
             array_key_exists('debugMode', $_POST)
             && in_array($_POST['debugMode'], ['0', '1'], true)
-            && (bool) $square->debug_mode() !== (bool) $_POST['debugMode']
+            && $square->debug_mode() !== (bool) $_POST['debugMode']
         ) {
             $square->save(['PMD_debug_mode' => $_POST['debugMode']]);
         }

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -108,7 +108,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
             || empty($_GET[ Domain::META_KEY_MERCHANT_ID ])
             || empty($_GET[ Domain::META_KEY_REFRESH_TOKEN ])
             || empty($_GET[ Domain::META_KEY_APPLICATION_ID ])
-            || empty($_GET[ Domain::META_KEY_LIVE_MODE ])
+            || ! isset($_GET[ Domain::META_KEY_LIVE_MODE ])
         ) {
             // Missing parameters for some reason. Can't proceed.
             EED_SquareOnsiteOAuth::closeOauthWindow(esc_html__('Missing OAuth required parameters.', 'event_espresso'));
@@ -143,7 +143,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
                 Domain::META_KEY_REFRESH_TOKEN => $refresh_token,
                 Domain::META_KEY_EXPIRES_AT    => sanitize_key($_GET[ Domain::META_KEY_EXPIRES_AT ]),
                 Domain::META_KEY_MERCHANT_ID   => sanitize_text_field($_GET[ Domain::META_KEY_MERCHANT_ID ]),
-                Domain::META_KEY_LIVE_MODE     => sanitize_key($_GET[ Domain::META_KEY_LIVE_MODE ]),
+                Domain::META_KEY_LIVE_MODE     => (bool) sanitize_key($_GET[ Domain::META_KEY_LIVE_MODE ]),
                 Domain::META_KEY_USING_OAUTH   => true,
                 Domain::META_KEY_THROTTLE_TIME => date("Y-m-d H:i:s"),
             ]

--- a/payment_methods/SquareOnsite/forms/BillingForm.php
+++ b/payment_methods/SquareOnsite/forms/BillingForm.php
@@ -223,11 +223,12 @@ class BillingForm extends EE_Billing_Attendee_Info_Form
             $this->_pm_instance->get_extra_meta(Domain::META_KEY_ACCESS_TOKEN, true, ''),
             $this->_pm_instance->debug_mode()
         );
+
         return [
             'accessToken'       => $access_token,
             'appId'             => $this->_pm_instance->get_extra_meta(Domain::META_KEY_APPLICATION_ID, true),
             'locationId'        => $this->_pm_instance->get_extra_meta(Domain::META_KEY_LOCATION_ID, true),
-            'useDigitalWallet'  => $this->_pm_instance->get_extra_meta(Domain::META_KEY_USE_DIGITAL_WALLET, true),
+            'useDigitalWallet'  => $this->_pm_instance->get_extra_meta(Domain::META_KEY_USE_DIGITAL_WALLET, true, ''),
             'paymentMethodSlug' => $this->_pm_instance->slug(),
             'paymentCurrency'   => EE_Registry::instance()->CFG->currency->code,
             'payButtonText'     => esc_html__('Pay', 'event_espresso'),

--- a/payment_methods/SquareOnsite/forms/OAuthForm.php
+++ b/payment_methods/SquareOnsite/forms/OAuthForm.php
@@ -102,9 +102,6 @@ class OAuthForm extends EE_Form_Section_Proper
      */
     protected function oauthFormContents()
     {
-        // Check the token and refresh if needed.
-        EED_SquareOnsiteOAuth::checkAndRefreshToken($this->thePmInstance);
-
         // The contents.
         $subsections = [];
         $fieldHeading = EEH_HTML::th(

--- a/payment_methods/SquareOnsite/forms/SettingsForm.php
+++ b/payment_methods/SquareOnsite/forms/SettingsForm.php
@@ -130,7 +130,9 @@ class SettingsForm extends EE_Payment_Method_Form
         }
 
         if (isset($squareData[ Domain::META_KEY_USING_OAUTH ]) && $squareData[ Domain::META_KEY_USING_OAUTH ]) {
-            // First check the credentials and the API connection
+            // first check the token and refresh if needed
+            EED_SquareOnsiteOAuth::checkAndRefreshToken($pmInstance);
+            // check the credentials and the API connection
             $oauthHealthCheck = $this->oauthHealthCheck($pmInstance);
             // and reset the OAuth connection in case we are no longer authorized for some reason.
             if (isset($oauthHealthCheck['error'])) {


### PR DESCRIPTION
## Problem this Pull Request solves
Resolves #16 

This adds extra validation on the oAuth parameters when requesting the access token or refreshing it.
Also adds some redundant access token validation on the oAuth health check.

## Testing
* [ ] In the PM settings, authenticate with Square.
* [ ] Do a registration for a non free event and pay with Square.
* [ ] In the PM settings, deauthorize your connection (disconnect).
