### PR TITLE
Enhance domain validation

### DIFF
--- a/api/domains/DomainsApi.php
+++ b/api/domains/DomainsApi.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EventEspresso\Square\api\locations;
+namespace EventEspresso\Square\api\domains;
 
 use EventEspresso\Square\api\SquareApi;
 
@@ -9,21 +9,21 @@ use EventEspresso\Square\api\SquareApi;
  * handles Square Locations API calls
  *
  * @author  Nazar Kolivoshka
- * @package EventEspresso\Square\api\locations
- * @since   1.0.0.p
+ * @package EventEspresso\Square\api\domains
+ * @since   $VID:$
  */
-class LocationsApi
+class DomainsApi
 {
-
     /**
      * @var SquareApi
      */
-    protected $api;
+    protected SquareApi $api;
 
     /**
      * @var string
      */
-    protected $post_url;
+    protected string $request_url;
+
 
     /**
      * CancelOrder constructor.
@@ -32,32 +32,33 @@ class LocationsApi
      */
     public function __construct(SquareApi $api)
     {
-        $this->api      = $api;
-        $this->post_url = $this->api->apiEndpoint() . 'locations';
+        $this->api         = $api;
+        $this->request_url = $this->api->apiEndpoint() . 'apple-pay/domains';
     }
 
 
     /**
-     * Request a list of Locations for the merchant.
+     * Send a domain registration request.
      *
-     * @return Object|array
+     * @param string $domain_name
+     * @return array
      */
-    public function listLocations()
+    public function registerDomain(string $domain_name): array
     {
         // Submit the GET request.
-        $response = $this->api->sendRequest([], $this->post_url, 'GET');
+        $response = $this->api->sendRequest(['domain_name' => $domain_name], $this->request_url);
         // If it's an array - it's an error. So pass that further.
         if (is_array($response) && isset($response['error'])) {
             return $response;
         }
-        if (! isset($response->locations)) {
+        if (! isset($response->status)) {
             $request_error['error']['message'] = esc_html__(
-                'Error. No locations list returned in Locations request.',
+                'Error. Domain registration response unrecognizable.',
                 'event_espresso'
             );
             return $request_error;
         }
-        // Got the list, return it.
-        return $response->locations;
+        // Got registration status.
+        return ['status' => $response->status];
     }
 }

--- a/api/domains/DomainsApi.php
+++ b/api/domains/DomainsApi.php
@@ -17,12 +17,12 @@ class DomainsApi
     /**
      * @var SquareApi
      */
-    protected SquareApi $api;
+    protected $api;
 
     /**
      * @var string
      */
-    protected string $request_url;
+    protected $request_url;
 
 
     /**

--- a/assets/css/eea-square-oauth.css
+++ b/assets/css/eea-square-oauth.css
@@ -176,3 +176,48 @@
     font-size: 14px;
     font-weight: bold;
 }
+
+
+/** Register Domain button **/
+.eea-register-domain-btn {
+    display: inline-block;
+    margin-bottom: 1px;
+    cursor: pointer;
+    -webkit-font-smoothing: antialiased;
+    border: 0;
+    padding: 0 12px;
+    height: 30px;
+
+    font-size: 14px;
+    line-height: 30px;
+    color: white;
+    font-weight: bold;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.4);
+
+    -moz-border-radius: 4px;
+    -webkit-border-radius: 4px;
+    border-radius: 4px;
+
+    -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,0.25);
+    -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+
+    background-image: -webkit-linear-gradient(#4a4d4f, #272a2b 85%, #1b1c1c);
+    background-image: -moz-linear-gradient(#4a4d4f, #272a2b 85%, #1b1c1c);
+    background-image: -ms-linear-gradient(#4a4d4f, #272a2b 85%, #1b1c1c);
+    background-image: linear-gradient(#4a4d4f, #272a2b 85%, #1b1c1c);
+}
+.eea-register-domain-btn:active {
+    color: #e7e7e7;
+
+    -moz-box-shadow: inset 0 1px 0 rgba(0,0,0,0.1);
+    -webkit-box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.1);
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.1);
+
+    background: #272a2b;
+    background-image: -webkit-linear-gradient(#272a2b, #272a2b 85%, #1b1c1d);
+    background-image: -moz-linear-gradient(#272a2b, #272a2b 85%, #1b1c1d);
+    background-image: -ms-linear-gradient(#272a2b, #272a2b 85%, #1b1c1d);
+    background-image: linear-gradient(#272a2b, #272a2b 85%, #1b1c1d);
+}

--- a/assets/js/eea-square-oauth.js
+++ b/assets/js/eea-square-oauth.js
@@ -17,6 +17,8 @@ jQuery(document).ready(function($) {
 	 *	debugModeInput: object,
 	 *	submittedPm: string,
 	 *	debugMode: string,
+	 *	registerDomainBtn: object,
+	 *	registerDomainBtnId: string,
 	 * }}
 	 *
 	 * @namespace eeaSquareOAuthParameters
@@ -44,10 +46,12 @@ jQuery(document).ready(function($) {
 		this.initialized = false;
 		this.connectBtn = {};
 		this.disconnectBtn = {};
+		this.registerDomainBtn = {};
 		this.form = {};
 		this.connectBtnId = '#eea_square_connect_btn_' + this.slug;
 		this.disconnectBtnId = '#eea_square_disconnect_btn_' + this.slug;
 		this.connectSectionId = '#eea_square_oauth_section_' + this.slug;
+		this.registerDomainBtnId = '#eea_apple_register_domain_' + this.slug;
 		this.useDwalletId = '#' + this.slug + '-use-dwallet';
 		this.connectSection = 'eea-connect-section-' + this.slug;
 		this.disconnectSection = 'eea-disconnect-section-' + this.slug;
@@ -90,6 +94,7 @@ jQuery(document).ready(function($) {
 		this.initializeObjects = function() {
 			this.connectBtn = $(this.connectBtnId);
 			this.disconnectBtn = $(this.disconnectBtnId);
+			this.registerDomainBtn = $(this.registerDomainBtnId);
 			this.form = $(this.formId);
 			this.debugModeInput = this.form.closest('form').find('select[name*='+this.slug+'][name*=PMD_debug_mode]');
 		};
@@ -206,6 +211,42 @@ jQuery(document).ready(function($) {
 					);
 					squarePmInstance.debugMode = squarePmInstance.debugModeInput[0].value;
 					squarePmInstance.oauthSendRequest('squareRequestDisconnect');
+				} else {
+					console.error(squareParams.unknownContainer);
+				}
+			});
+
+			$(this.registerDomainBtnId).on('click', function(event) {
+				event.preventDefault();
+				const buttonContainer = $(this).closest('tr');
+				const submittingForm = $(this).parents('form:first')[0];
+				if (buttonContainer && submittingForm) {
+					squarePmInstance.submittedPm = 'squareonsite';
+					squarePmInstance.debugMode = squarePmInstance.debugModeInput[0].value;
+					const requestData = {
+						action: 'squareRegisterDomain',
+						submittedPm: squarePmInstance.submittedPm,
+						debugMode: squarePmInstance.debugMode
+					};
+					$.ajax({
+						type: 'POST',
+						url: eei18n.ajax_url,
+						data: requestData,
+						dataType: 'json',
+						beforeSend: function() {
+							window.do_before_admin_page_ajax();
+						},
+						success: function(response) {
+							$('#' + squarePmInstance.processingIconName).fadeOut('fast');
+							console.log('--- OK', response);
+							alert(response.status);
+						},
+						error: function(response, error, description) {
+							$('#' + squarePmInstance.processingIconName).fadeOut('fast');
+							console.log('--- error', description);
+							alert(description);
+						}
+					});
 				} else {
 					console.error(squareParams.unknownContainer);
 				}

--- a/assets/js/eea-square-oauth.js
+++ b/assets/js/eea-square-oauth.js
@@ -238,12 +238,19 @@ jQuery(document).ready(function($) {
 						},
 						success: function(response) {
 							$('#' + squarePmInstance.processingIconName).fadeOut('fast');
-							console.log('--- OK', response);
-							alert(response.status);
+							console.log(response);
+							if (typeof response.status !== 'undefined') {
+							    // hide the button
+							    const domainNameSection = squarePmInstance.registerDomainBtn.closest('tr');
+							    domainNameSection.hide();
+							    alert(response.status);
+                            }
+							if (typeof response.squareError !== 'undefined') {
+							    alert(response.squareError);
+                            }
 						},
 						error: function(response, error, description) {
 							$('#' + squarePmInstance.processingIconName).fadeOut('fast');
-							console.log('--- error', description);
 							alert(description);
 						}
 					});
@@ -366,7 +373,7 @@ jQuery(document).ready(function($) {
 				success: function(response) {
 					squarePmInstance.oauthRequestSuccess(response, requestAction);
 				},
-				error: squarePmInstance.oauthRequestError,
+				error: squarePmInstance.requestError,
 			});
 		};
 
@@ -417,19 +424,19 @@ jQuery(document).ready(function($) {
 			}
 		};
 
-		this.oauthRequestError = function(response, error, description) {
-			let squareError = squareParams.errorResponse;
+		this.requestError = function(response, err, description) {
+			let error = squareParams.errorResponse;
 			if (description) {
-				squareError = squareError + ': ' + description;
+				error = error + ': ' + description;
 			}
 			$('#' + this.processingIconName).fadeOut('fast');
-			console.error(squareError);
+			console.error(error);
 			// Display the error in the pop-up.
 			if (this.oauthWindow) {
 				this.oauthWindow.document.getElementById(
 					this.processingIconName
 				).style.display = 'none';
-				$(this.oauthWindow.document.body).html(squareError);
+				$(this.oauthWindow.document.body).html(error);
 				this.oauthWindow = null;
 			}
 			if (typeof response.alert !== 'undefined' && response.alert) {
@@ -496,6 +503,7 @@ jQuery(document).ready(function($) {
 					const disconnectSection = $('.' + squareInstance.disconnectSection);
 					const locationsSelect = $('.' + squareInstance.locationsSelect);
 					const locationsSection = locationsSelect.closest('tr');
+					const domainNameSection = squareInstance.registerDomainBtn.closest('tr');
 
 					if (typeof response.connected !== 'undefined' && response.connected) {
 						connectSection.hide();
@@ -528,6 +536,7 @@ jQuery(document).ready(function($) {
 						connectSection.show();
 						disconnectSection.hide();
 						locationsSection.hide();
+						domainNameSection.hide();
 						if (squareParams.canDisableInput) {
 							// Enable the debug mode selector.
 							squareInstance.debugModeInput.prop('disabled', false);

--- a/domain/Domain.php
+++ b/domain/Domain.php
@@ -81,6 +81,11 @@ class Domain
     public const SQUARE_API_VERSION = '2021-05-13';
 
     /*
+     * Name of the Extra Meta that stores the domain verification status.
+     */
+    public const META_KEY_DOMAIN_VERIFY = 'domain_verified';
+
+    /*
      * Holds the name of the Register Domain button.
      */
     public const META_KEY_REG_DOMAIN_BUTTON = 'register_domain';

--- a/domain/Domain.php
+++ b/domain/Domain.php
@@ -79,4 +79,9 @@ class Domain
      * Holds the Square API version used in this integration.
      */
     public const SQUARE_API_VERSION = '2021-05-13';
+
+    /*
+     * Holds the name of the Register Domain button.
+     */
+    public const META_KEY_REG_DOMAIN_BUTTON = 'register_domain';
 }

--- a/payment_methods/SquareOnsite/forms/SettingsForm.php
+++ b/payment_methods/SquareOnsite/forms/SettingsForm.php
@@ -28,14 +28,14 @@ class SettingsForm extends EE_Payment_Method_Form
      *
      * @var array
      */
-    protected array $squareData = [];
+    protected $squareData = [];
 
     /**
      *  The list of locations.
      *
      * @var array
      */
-    protected array $locations_list = [];
+    protected $locations_list = [];
 
     /**
      * Class constructor.


### PR DESCRIPTION
This resolves #18 

This adds auto domain registration when Digital Wallet get's enabled (and PM settings page is saved).

This also adds a "Register my site Domain" button on the settings page in case the domain was not verified with Apple in the time of auto registration mentioned above. This allows the user to trigger the domain registration manually.

Note: users that host this add-on on their own website [need to Verify](https://developer.squareup.com/docs/web-payments/apple-pay#step-1-register-your-sandbox-domain-with-apple) their domain name with Apple before they can register it in our App (PM settings page) and use Apple pay to checkout.

### Testing:
* [ ] Coming up...