### PR TITLE
Add php version check

### DIFF
--- a/eea-square-gateway.php
+++ b/eea-square-gateway.php
@@ -8,7 +8,7 @@
 
     Author: Event Espresso
     Author URI: https://eventespresso.com
-    Copyright 2020 Event Espresso (email : support@eventespresso.com)
+    Copyright 2021 Event Espresso (email : support@eventespresso.com)
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License, version 2, as
@@ -37,4 +37,37 @@ function loadEEASquareGateway()
     }
 }
 add_action('AHEE__EE_System__load_espresso_addons', 'loadEEASquareGateway');
+
+// Check PHP version etc.
+function eeaSquareCheckPhpAndComponents()
+{
+    if (version_compare(PHP_VERSION, '7.1', '<')) {
+        if (isset($_GET['activate'])) {
+            unset($_GET['activate']);
+            unset($_REQUEST['activate']);
+        }
+
+        if (! function_exists('deactivate_plugins')) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+        deactivate_plugins(plugin_basename(EEA_SQUARE_GATEWAY_PLUGIN_FILE));
+        add_action('admin_notices', 'eeaSquareDisablePmNotice');
+    }
+}
+add_action('admin_init', 'eeaSquareCheckPhpAndComponents');
+
+// The deactivation notice.
+function eeaSquareDisablePmNotice()
+{
+    echo '<div class="error"><p>'
+         . sprintf(
+             esc_html__(
+                 '%1$s Event Espresso - Square Gateway %2$s was deactivated! This plugin requires a %1$sPHP version 7.1 or higher%2$s to work properly.',
+                 'event_espresso'
+             ),
+             '<strong>',
+             '</strong>'
+         )
+         . '</p></div>';
+}
 // End of file eea-square-gateway.php

--- a/eea-square-gateway.php
+++ b/eea-square-gateway.php
@@ -31,30 +31,28 @@ define('EEA_SQUARE_GATEWAY_PLUGIN_PATH', plugin_dir_path(__FILE__));
 // Register this add-on with EE.
 function loadEEASquareGateway()
 {
-    if (class_exists('EE_Addon')) {
-        require_once(EEA_SQUARE_GATEWAY_PLUGIN_PATH . 'EE_SquareGateway.class.php');
-        EE_SquareGateway::registerAddon();
+    if (version_compare(PHP_VERSION, '7.1', '>=')) {
+        if (class_exists('EE_Addon')) {
+            require_once(EEA_SQUARE_GATEWAY_PLUGIN_PATH . 'EE_SquareGateway.class.php');
+            EE_SquareGateway::registerAddon();
+        }
+    } else {
+        // Incompatible PHP version, disable the plugin.
+        add_action('admin_init', 'eeaSquareDisablePm');
     }
 }
 add_action('AHEE__EE_System__load_espresso_addons', 'loadEEASquareGateway');
 
 // Check PHP version etc.
-function eeaSquareCheckPhpAndComponents()
+function eeaSquareDisablePm()
 {
-    if (version_compare(PHP_VERSION, '7.1', '<')) {
-        if (isset($_GET['activate'])) {
-            unset($_GET['activate']);
-            unset($_REQUEST['activate']);
-        }
-
-        if (! function_exists('deactivate_plugins')) {
-            require_once ABSPATH . 'wp-admin/includes/plugin.php';
-        }
-        deactivate_plugins(plugin_basename(EEA_SQUARE_GATEWAY_PLUGIN_FILE));
-        add_action('admin_notices', 'eeaSquareDisablePmNotice');
+    unset($_GET['activate'], $_REQUEST['activate']);
+    if (! function_exists('deactivate_plugins')) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
     }
+    deactivate_plugins(plugin_basename(EEA_SQUARE_GATEWAY_PLUGIN_FILE));
+    add_action('admin_notices', 'eeaSquareDisablePmNotice');
 }
-add_action('admin_init', 'eeaSquareCheckPhpAndComponents');
 
 // The deactivation notice.
 function eeaSquareDisablePmNotice()


### PR DESCRIPTION
Resolves #20 

This adds a min PHP version 7.1 check and disables the add-on if the criteria is not met, displaying an admin notice.

### Testing:

* [ ] Try enabling Square with PHP that's `< 7.1`. The add-on will deactivate and should show an admin notice.