### PR TITLE
Add Customers API

### DIFF
--- a/api/ResponseHandler.php
+++ b/api/ResponseHandler.php
@@ -60,6 +60,17 @@ class ResponseHandler
     }
 
 
+    /**
+     * This removes all errors from the list.
+     *
+     * @return void
+     */
+    public function clearErrors()
+    {
+        $this->errors = [];
+    }
+
+
     private function setInValid()
     {
         $this->valid = false;

--- a/api/customers/CustomersApi.php
+++ b/api/customers/CustomersApi.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace EventEspresso\Square\api\customers;
+
+use EE_Registration;
+use EED_SquareOnsite;
+use EventEspresso\Square\api\SquareApi;
+
+/**
+ * Class CustomersApi
+ *
+ * Handles Square Customers API calls.
+ *
+ * @author  Nazar Kolivoshka
+ * @package EventEspresso\Square\api\customers
+ * @since   $VID:$
+ */
+class CustomersApi
+{
+
+    /**
+     * @var SquareApi
+     */
+    protected $api;
+
+    /**
+     * @var string
+     */
+    protected $post_url;
+
+    /**
+     * Customer's billing info.
+     *
+     * @var array
+     */
+    protected $billing_info = [];
+
+    /**
+     * @var EE_Registration
+     */
+    protected $primary_registrant;
+
+
+    /**
+     * Class constructor.
+     *
+     * @param SquareApi $api
+     * @param array $billing_info
+     * @param EE_Registration $primary_registrant
+     */
+    public function __construct(SquareApi $api, array $billing_info, EE_Registration $primary_registrant)
+    {
+        $this->api                = $api;
+        $this->post_url           = $this->api->apiEndpoint() . 'customers/';
+        $this->billing_info       = $billing_info;
+        $this->primary_registrant = $primary_registrant;
+    }
+
+
+    /**
+     * Searches the customer profiles associated with a Square account using a supported query filter.
+     *
+     * @param       $filter
+     * @param array $sort
+     * @param int   $limit
+     * @return array
+     */
+    public function search($filter, array $sort = ['field' => 'CREATED_AT'], int $limit = 1): array
+    {
+        $search_parameters = [
+            'query' => [
+                'filter' => $filter,
+                'sort'   => $sort,
+            ],
+            'limit' => $limit,
+        ];
+        // Submit the search request.
+        $response = $this->api->sendRequest($search_parameters, $this->post_url . 'search');
+        // Do we have an error ?
+        if (is_array($response) && isset($response['error'])) {
+            return $response;
+        }
+        if (! $response || ! isset($response->customers)) {
+            // Square return an empty body if nothing is found, so we return an empty array.
+            return [];
+        }
+        // Got customer/s, return it.
+        return $response->customers;
+    }
+
+
+    /**
+     * Searches for the customer profile by his email.
+     *
+     * @param string $email
+     * @return array
+     */
+    public function findByEmail(string $email): array
+    {
+        $filter['email_address'] = ['exact' => $email];
+        return $this->search($filter);
+    }
+
+
+    /**
+     * Creates a new customer for a business.
+     *
+     * @return Object|array
+     */
+    public function create()
+    {
+        try {
+            $country_iso = EED_SquareOnsite::getCountryIsoByName($this->billing_info['country']);
+        } catch (\EE_Error | \ReflectionException $e) {
+            $country_iso = '';
+        }
+        $parameters = [
+            'given_name'    => $this->billing_info['first_name'] ?? '',
+            'family_name'   => $this->billing_info['last_name'] ?? '',
+            'email_address' => $this->billing_info['email'] ?? '',
+            'address' => [
+                'address_line_1' => $this->billing_info['address'] ?? '',
+                'address_line_2' => $this->billing_info['address2'] ?? '',
+                'locality'       => $this->billing_info['city'] ?? '',
+                'administrative_district_level_1' => $this->billing_info['state'] ?? '',
+                'postal_code'    => $this->billing_info['zip'] ?? '',
+                'country'        => $country_iso ?? '',
+            ],
+            'phone_number' => $this->billing_info['phone'] ?? '',
+            'reference_id' => (string) $this->primary_registrant->attendee_ID(),
+            'note'         => 'An event attendee'
+        ];
+
+        // Submit the create request.
+        $response = $this->api->sendRequest($parameters, $this->post_url);
+        // Do we have an error ?
+        if (is_array($response) && isset($response['error'])) {
+            return $response;
+        }
+        if (! isset($response->customer)) {
+            $request_error['error']['message'] = esc_html__(
+                'Error. Customer was not saved in Square. Unrecognized error.',
+                'event_espresso'
+            );
+            return $request_error;
+        }
+        // Got it, return it.
+        return $response->customer;
+    }
+}

--- a/api/customers/CustomersApi.php
+++ b/api/customers/CustomersApi.php
@@ -2,9 +2,11 @@
 
 namespace EventEspresso\Square\api\customers;
 
+use EE_Error;
 use EE_Registration;
 use EED_SquareOnsite;
 use EventEspresso\Square\api\SquareApi;
+use ReflectionException;
 
 /**
  * Class CustomersApi
@@ -17,7 +19,6 @@ use EventEspresso\Square\api\SquareApi;
  */
 class CustomersApi
 {
-
     /**
      * @var SquareApi
      */
@@ -81,7 +82,7 @@ class CustomersApi
             return $response;
         }
         if (! $this->hasCustomerData($response)) {
-            // Square return an empty body if nothing is found, so we return an empty array.
+            // Square returns an empty body if nothing is found, so we return an empty array.
             return [];
         }
         // Got customer/s, return it.
@@ -111,7 +112,7 @@ class CustomersApi
     {
         try {
             $country_iso = EED_SquareOnsite::getCountryIsoByName($this->billing_info['country']);
-        } catch (\EE_Error | \ReflectionException $e) {
+        } catch (EE_Error | ReflectionException $e) {
             $country_iso = '';
         }
         $parameters = [

--- a/api/customers/CustomersApi.php
+++ b/api/customers/CustomersApi.php
@@ -77,10 +77,10 @@ class CustomersApi
         // Submit the search request.
         $response = $this->api->sendRequest($search_parameters, $this->post_url . 'search');
         // Do we have an error ?
-        if (is_array($response) && isset($response['error'])) {
+        if ($this->isErrorResponse($response)) {
             return $response;
         }
-        if (! $response || ! isset($response->customers)) {
+        if (! $this->hasCustomerData($response)) {
             // Square return an empty body if nothing is found, so we return an empty array.
             return [];
         }
@@ -134,10 +134,10 @@ class CustomersApi
         // Submit the create request.
         $response = $this->api->sendRequest($parameters, $this->post_url);
         // Do we have an error ?
-        if (is_array($response) && isset($response['error'])) {
+        if ($this->isErrorResponse($response)) {
             return $response;
         }
-        if (! isset($response->customer)) {
+        if (! $this->hasCustomerData($response)) {
             $request_error['error']['message'] = esc_html__(
                 'Error. Customer was not saved in Square. Unrecognized error.',
                 'event_espresso'
@@ -146,5 +146,29 @@ class CustomersApi
         }
         // Got it, return it.
         return $response->customer;
+    }
+
+
+    /**
+     * Check the response for a customer object.
+     *
+     * @param $response
+     * @return bool
+     */
+    private function hasCustomerData($response): bool
+    {
+        return $response && isset($response->customer);
+    }
+
+
+    /**
+     * Check the response for errors.
+     *
+     * @param $response
+     * @return bool
+     */
+    private function isErrorResponse($response): bool
+    {
+        return is_array($response) && isset($response['error']);
     }
 }

--- a/api/order/CancelOrder.php
+++ b/api/order/CancelOrder.php
@@ -16,11 +16,11 @@ class CancelOrder extends OrdersApi
     /**
      * Cancel the Square Order.
      *
-     * @param string         $orderId
-     * @param string         $orderVersion
+     * @param string  $order_id
+     * @param string  $order_version
      * @return Object|array
      */
-    public function cancel(string $orderId, string $orderVersion)
+    public function cancel(string $order_id, string $order_version)
     {
         // Send cancel Order request.
         return $this->api->sendRequest(
@@ -28,11 +28,11 @@ class CancelOrder extends OrdersApi
                 'idempotency_key' => $this->idempotency_key->value(),
                 'order'           => [
                     'location_id' => $this->api->locationId(),
-                    'version'     => (int)$orderVersion + 1,
+                    'version'     => (int)$order_version + 1,
                     'state'       => 'CANCELED',
                 ],
             ],
-            $this->post_url . $orderId,
+            $this->post_url . $order_id,
             'PUT'
         );
     }

--- a/api/order/OrderItems.php
+++ b/api/order/OrderItems.php
@@ -27,6 +27,11 @@ class OrderItems
     /**
      * @var array
      */
+    protected $fulfillments = [];
+
+    /**
+     * @var array
+     */
     protected $discount_IDs = [];
 
     /**
@@ -61,6 +66,15 @@ class OrderItems
         $this->discounts[] = $discount;
         // Also track discount UUIDs separately, for line items 'applied_discounts' parameter.
         $this->addDiscountID($discount['uid']);
+    }
+
+
+    /**
+     * @param array $fulfillment
+     */
+    public function addFulfillment(array $fulfillment)
+    {
+        $this->fulfillments[] = $fulfillment;
     }
 
 
@@ -123,6 +137,15 @@ class OrderItems
     /**
      * @return array
      */
+    public function fulfillments(): array
+    {
+        return $this->fulfillments;
+    }
+
+
+    /**
+     * @return array
+     */
     public function discountIDs(): array
     {
         return $this->discount_IDs;
@@ -153,6 +176,15 @@ class OrderItems
     public function hasDiscounts(): bool
     {
         return ! empty($this->discounts);
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function hasFulfillments(): bool
+    {
+        return ! empty($this->fulfillments);
     }
 
 

--- a/api/payment/PaymentApi.php
+++ b/api/payment/PaymentApi.php
@@ -6,6 +6,7 @@ use EE_Error;
 use EE_Payment;
 use EED_SquareOnsite;
 use EEG_SquareOnsite;
+use EventEspresso\Square\api\customers\CustomersApi;
 use EventEspresso\Square\api\IdempotencyKey;
 use EventEspresso\Square\api\SquareApi;
 use ReflectionException;
@@ -63,28 +64,38 @@ class PaymentApi
      */
     protected $billing_info = [];
 
+    /**
+     * The Customers API instance.
+     *
+     * @var CustomersApi
+     */
+    protected $customers_api;
+
 
     /**
      * CancelOrder constructor.
      *
      * @param EEG_SquareOnsite $gateway
      * @param SquareApi        $api
+     * @param CustomersApi     $customers_api
      * @param array            $billing_info
      * @param int              $TXN_ID
      */
     public function __construct(
         EEG_SquareOnsite $gateway,
         SquareApi $api,
+        CustomersApi $customers_api,
         array $billing_info,
         int $TXN_ID
     ) {
         $this->api               = $api;
         $this->gateway           = $gateway;
+        $this->billing_info      = $billing_info;
+        $this->customers_api     = $customers_api;
         $this->payment_token     = $billing_info['eea_square_token'] ?? '';
         $this->verificationToken = $billing_info['eea_square_sca'] ?? '';
         $this->post_url          = $this->api->apiEndpoint() . 'payments';
         $this->idempotency_key   = new IdempotencyKey($this->api->isSandboxMode(), $TXN_ID);
-        $this->billing_info      = $billing_info;
     }
 
 
@@ -141,7 +152,7 @@ class PaymentApi
         }
         if (! isset($response->payment)) {
             $request_error['error']['message'] = esc_html__(
-                'Unexpected error. No order returned in Order create response.',
+                'Unexpected error. No payment returned in Payment create response.',
                 'event_espresso'
             );
             return $request_error;
@@ -186,6 +197,18 @@ class PaymentApi
                 'postal_code'    => $this->billing_info['zip'] ?? '',
             ],
         ];
+
+        // Search to see if this user already exists as a customer.
+        $found_customer = $this->customers_api->findByEmail($this->billing_info['email']);
+        if (! $found_customer) {
+            $customer = $this->customers_api->create();
+            if (is_object($customer)) {
+                $payment_body['customer_id'] = $customer->id;
+            }
+        } else if (is_array($found_customer) && ! empty($found_customer[0]->id)) {
+            // Customer already exists. Need only one.
+            $payment_body['customer_id'] = $found_customer[0]->id;
+        }
 
         // Is there a verifications token (SCA) ?
         if ($this->verificationToken) {

--- a/domain/Domain.php
+++ b/domain/Domain.php
@@ -97,15 +97,15 @@ class Domain
     /**
      * The default required permissions scope to be able to use all the API methods needed by this add-on.
      */
-    public const MINIMAL_PERMISSIONS_SCOPE = 'PAYMENTS_WRITE PAYMENTS_READ ORDERS_WRITE ORDERS_READ MERCHANT_PROFILE_READ';
+    public const PERMISSIONS_SCOPE_MINIMAL = 'PAYMENTS_WRITE PAYMENTS_READ ORDERS_WRITE ORDERS_READ MERCHANT_PROFILE_READ';
 
     /**
      * Customers API required permissions.
      */
-    public const CUSTOMERS_PERMISSIONS_SCOPE = 'CUSTOMERS_READ CUSTOMERS_WRITE';
+    public const PERMISSIONS_SCOPE_CUSTOMERS = 'CUSTOMERS_READ CUSTOMERS_WRITE';
 
     /**
      * The default required permissions scope to be able to use all the API methods needed by this add-on.
      */
-    public const PERMISSIONS_SCOPE = self::MINIMAL_PERMISSIONS_SCOPE . ' ' . self::CUSTOMERS_PERMISSIONS_SCOPE;
+    public const PERMISSIONS_SCOPE_ALL = self::PERMISSIONS_SCOPE_MINIMAL . ' ' . self::PERMISSIONS_SCOPE_CUSTOMERS;
 }

--- a/domain/Domain.php
+++ b/domain/Domain.php
@@ -12,7 +12,6 @@ namespace EventEspresso\Square\domain;
  */
 class Domain
 {
-
     /**
      * Name of Extra Meta that stores the Square Application ID used in API calls.
      */
@@ -48,45 +47,65 @@ class Domain
      */
     public const META_KEY_MERCHANT_ID = 'merchant_id';
 
-    /*
+    /**
      * Name of the Extra Meta that stores the Square account location ID.
      */
     public const META_KEY_LOCATION_ID = 'location_id';
 
-    /*
+    /**
      * Name of the Extra Meta key that stores the merchant locations list.
      */
     public const META_KEY_LOCATIONS_LIST = 'locations_list';
 
-    /*
+    /**
      * Name of the Extra Meta that stores the option for enabling the Square Digital Wallet (Google Pay and Apple Pay).
      */
     public const META_KEY_USE_DIGITAL_WALLET = 'use_dwallet';
 
-    /*
+    /**
      * Name of the Extra Meta that stores the option for the refresh token requests throttle window.
      */
     public const META_KEY_THROTTLE_TIME = 'throttle_time';
 
-    /*
+    /**
      * Name of the Extra Meta key that stores a few options as one meta (combined).
      * These are saved under this key:
-     * refresh_token, expires_at, merchant_id, using_square_oauth, throttle_time, locations_list.
+     * refresh_token, expires_at, merchant_id, using_square_oauth, throttle_time, locations_list, permissions_scope.
      */
     public const META_KEY_SQUARE_DATA = 'square_data';
 
-    /*
+    /**
      * Holds the Square API version used in this integration.
      */
     public const SQUARE_API_VERSION = '2021-05-13';
 
-    /*
+    /**
      * Name of the Extra Meta that stores the domain verification status.
      */
     public const META_KEY_DOMAIN_VERIFY = 'domain_verified';
 
-    /*
+    /**
      * Holds the name of the Register Domain button.
      */
     public const META_KEY_REG_DOMAIN_BUTTON = 'register_domain';
+
+    /**
+     * Name of the Extra Meta that stores the authenticated permissions scope.
+     */
+    public const META_KEY_PERMISSIONS = 'permissions_scope';
+
+    /**
+     * The default required permissions scope to be able to use all the API methods needed by this add-on.
+     */
+    public const MINIMAL_PERMISSIONS_SCOPE = 'PAYMENTS_WRITE PAYMENTS_READ ORDERS_WRITE ORDERS_READ MERCHANT_PROFILE_READ';
+
+    /**
+     * Customers API required permissions.
+     */
+    public const CUSTOMERS_PERMISSIONS_SCOPE = 'CUSTOMERS_READ CUSTOMERS_WRITE';
+
+    /**
+     * The default required permissions scope to be able to use all the API methods needed by this add-on.
+     */
+    public const PERMISSIONS_SCOPE = self::MINIMAL_PERMISSIONS_SCOPE . ' ' . self::CUSTOMERS_PERMISSIONS_SCOPE;
 }

--- a/modules/EED_SquareOnsite.module.php
+++ b/modules/EED_SquareOnsite.module.php
@@ -91,25 +91,25 @@ class EED_SquareOnsite extends EED_Module
         if (! $paymentMethod instanceof EE_Payment_Method) {
             return;
         }
-        $orderId      = $transaction->get_extra_meta('order_id', true, false);
-        $orderVersion = $transaction->get_extra_meta('order_version', true, false);
-        $pmSettings   = $paymentMethod->settings_array();
-        $access_token = ! empty($pmSettings[ Domain::META_KEY_ACCESS_TOKEN ])
+        $order_id      = $transaction->get_extra_meta('order_id', true, false);
+        $order_version = $transaction->get_extra_meta('order_version', true, false);
+        $pm_settings   = $paymentMethod->settings_array();
+        $access_token  = ! empty($pm_settings[ Domain::META_KEY_ACCESS_TOKEN ])
             ? EED_SquareOnsiteOAuth::decryptString(
-                $pmSettings[ Domain::META_KEY_ACCESS_TOKEN ],
-                $pmSettings['debug_mode']
+                $pm_settings[ Domain::META_KEY_ACCESS_TOKEN ],
+                $pm_settings['debug_mode']
             )
             : false;
-        if ($orderId && $access_token) {
+        if ($order_id && $access_token) {
             $SquareApi = new SquareApi(
                 $access_token,
-                $pmSettings[ Domain::META_KEY_APPLICATION_ID ],
-                $pmSettings[ Domain::META_KEY_USE_DIGITAL_WALLET ],
-                $pmSettings['debug_mode'],
-                $pmSettings[ Domain::META_KEY_LOCATION_ID ]
+                $pm_settings[ Domain::META_KEY_APPLICATION_ID ],
+                $pm_settings[ Domain::META_KEY_USE_DIGITAL_WALLET ],
+                $pm_settings['debug_mode'],
+                $pm_settings[ Domain::META_KEY_LOCATION_ID ]
             );
             $CancelOrder = new CancelOrder($SquareApi, $transaction->ID());
-            $CancelOrder->cancel($orderId, $orderVersion);
+            $CancelOrder->cancel($order_id, $order_version);
         }
     }
 

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -214,7 +214,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
             [
                 'return_url' => rawurlencode($redirectUri),
                 'scope'      => urlencode(
-                    'PAYMENTS_WRITE PAYMENTS_READ ORDERS_WRITE ORDERS_READ MERCHANT_PROFILE_READ'
+                    'PAYMENTS_WRITE PAYMENTS_READ ORDERS_WRITE ORDERS_READ MERCHANT_PROFILE_READ CUSTOMERS_READ CUSTOMERS_WRITE'
                 ),
                 'modal'      => true
             ],

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -151,7 +151,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
          * Save the permissions scope. Used for checking the permissions before using the API.
          * @since $VID:$
          */
-        $square_pm->update_extra_meta(Domain::META_KEY_PERMISSIONS, Domain::PERMISSIONS_SCOPE);
+        $square_pm->update_extra_meta(Domain::META_KEY_PERMISSIONS, Domain::PERMISSIONS_SCOPE_ALL);
 
         $refresh_token = EED_SquareOnsiteOAuth::encryptString(
             sanitize_text_field($_GET[ Domain::META_KEY_REFRESH_TOKEN ]),
@@ -182,7 +182,6 @@ class EED_SquareOnsiteOAuth extends EED_Module
      * @throws InvalidInterfaceException
      * @throws InvalidDataTypeException
      * @throws EE_Error
-     * @throws ReflectionException
      */
     public static function getConnectionData()
     {
@@ -218,7 +217,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
         $request_url = add_query_arg(
             [
                 'return_url' => rawurlencode($redirect_uri),
-                'scope'      => urlencode(Domain::PERMISSIONS_SCOPE),
+                'scope'      => urlencode(Domain::PERMISSIONS_SCOPE_ALL),
                 'modal'      => true
             ],
             EED_SquareOnsiteOAuth::getMiddlemanBaseUrl($square) . 'forward'

--- a/payment_methods/SquareOnsite/EEG_SquareOnsite.gateway.php
+++ b/payment_methods/SquareOnsite/EEG_SquareOnsite.gateway.php
@@ -91,7 +91,7 @@ class EEG_SquareOnsite extends EE_Onsite_Gateway
         $customer_id    = '';
         // Check if we have the correct permissions before we try to use the API.
         $oauth_permissions = $payment_method->get_extra_meta(Domain::META_KEY_PERMISSIONS, true);
-        if ($oauth_permissions && strpos($oauth_permissions, Domain::CUSTOMERS_PERMISSIONS_SCOPE) !== false) {
+        if ($oauth_permissions && strpos($oauth_permissions, Domain::PERMISSIONS_SCOPE_CUSTOMERS) !== false) {
             // Get the Customer ID.
             $customer_id = $this->getCustomerId($transaction, $billing_info);
         }

--- a/payment_methods/SquareOnsite/EEG_SquareOnsite.gateway.php
+++ b/payment_methods/SquareOnsite/EEG_SquareOnsite.gateway.php
@@ -482,6 +482,6 @@ class EEG_SquareOnsite extends EE_Onsite_Gateway
         // Associate the Customer with this transaction.
         $transaction->add_extra_meta('customer_id', $customer_id);
         // Just make sure we return a string.
-        return $customer_id ?? '';
+        return $customer_id ?: '';
     }
 }

--- a/payment_methods/SquareOnsite/EEG_SquareOnsite.gateway.php
+++ b/payment_methods/SquareOnsite/EEG_SquareOnsite.gateway.php
@@ -465,10 +465,10 @@ class EEG_SquareOnsite extends EE_Onsite_Gateway
         $customer_id = $transaction->get_extra_meta('customer_id', true, '');
         if (! $customer_id) {
             // Create a customer for this transaction.
-            $primary_registrant  = $transaction->primary_registration();
-            $customers_api       = $this->getCustomersApi($billing_info, $primary_registrant);
+            $primary_registrant = $transaction->primary_registration();
+            $customers_api      = $this->getCustomersApi($billing_info, $primary_registrant);
             // Search to see if this user already exists as a customer.
-            $found_customer      = $customers_api->findByEmail($billing_info['email']);
+            $found_customer     = $customers_api->findByEmail($billing_info['email']);
             if (! $found_customer) {
                 $customer = $customers_api->create();
                 if (is_object($customer)) {
@@ -481,6 +481,7 @@ class EEG_SquareOnsite extends EE_Onsite_Gateway
         }
         // Associate the Customer with this transaction.
         $transaction->add_extra_meta('customer_id', $customer_id);
-        return $customer_id;
+        // Just make sure we return a string.
+        return $customer_id ?? '';
     }
 }

--- a/payment_methods/SquareOnsite/EEG_SquareOnsite.gateway.php
+++ b/payment_methods/SquareOnsite/EEG_SquareOnsite.gateway.php
@@ -91,9 +91,15 @@ class EEG_SquareOnsite extends EE_Onsite_Gateway
         $customer_id    = '';
         // Check if we have the correct permissions before we try to use the API.
         $oauth_permissions = $payment_method->get_extra_meta(Domain::META_KEY_PERMISSIONS, true);
-        if ($oauth_permissions && strpos($oauth_permissions, Domain::PERMISSIONS_SCOPE_CUSTOMERS) !== false) {
-            // Get the Customer ID.
-            $customer_id = $this->getCustomerId($transaction, $billing_info);
+        if ($oauth_permissions) {
+            // Customers API:
+            if (
+                strpos($oauth_permissions, Domain::PERMISSIONS_SCOPE_CUSTOMERS) !== false
+                && ! empty($billing_info['consent_box']['consent'])
+            ) {
+                // Get the Customer ID.
+                $customer_id = $this->getCustomerId($transaction, $billing_info);
+            }
         }
         // Get the order ID.
         $order_id = $this->getOrderId($payment, $transaction, $payment_status, $customer_id);

--- a/payment_methods/SquareOnsite/forms/BillingForm.php
+++ b/payment_methods/SquareOnsite/forms/BillingForm.php
@@ -3,7 +3,10 @@
 namespace EventEspresso\Square\payment_methods\SquareOnsite\forms;
 
 use EE_Billing_Attendee_Info_Form;
+use EE_Checkbox_Multi_Input;
+use EE_Div_Per_Section_Layout;
 use EE_Error;
+use EE_Form_Section_Base;
 use EE_Form_Section_HTML;
 use EE_Form_Section_Proper;
 use EE_Hidden_Input;
@@ -107,6 +110,7 @@ class BillingForm extends EE_Billing_Attendee_Info_Form
                 'html_id' => 'square-onsite-billing-form',
                 'html_class' => 'squareOnsite_billingForm',
                 'subsections' => [
+                    'consent_box'      => $this->consentBox(),
                     'debug_content'    => $this->addDebugContent($paymentMethod),
                     'square_pm_form'   => $this->squareEmbeddedForm(),
                     'eea_square_token' => new EE_Hidden_Input([
@@ -131,10 +135,10 @@ class BillingForm extends EE_Billing_Attendee_Info_Form
      * Possibly adds debug content to Square billing form.
      *
      * @param EE_Payment_Method $paymentMethod
-     * @return EE_Form_Section_Proper
+     * @return EE_Form_Section_Base
      * @throws EE_Error
      */
-    public function addDebugContent(EE_Payment_Method $paymentMethod)
+    public function addDebugContent(EE_Payment_Method $paymentMethod): EE_Form_Section_Base
     {
         if ($paymentMethod->debug_mode()) {
             return new EE_Form_Section_Proper([
@@ -154,7 +158,7 @@ class BillingForm extends EE_Billing_Attendee_Info_Form
      * @return EE_Form_Section_Proper
      * @throws EE_Error
      */
-    public function squareEmbeddedForm()
+    public function squareEmbeddedForm(): EE_Form_Section_Proper
     {
         $template_args = [];
         return new EE_Form_Section_Proper([
@@ -162,6 +166,38 @@ class BillingForm extends EE_Billing_Attendee_Info_Form
                 'layout_template_file' => $this->template_path . 'squareEmbeddedForm.template.php',
                 'template_args'        => $template_args
             ])
+        ]);
+    }
+
+
+    /**
+     * Form the consent box contents.
+     *
+     * @return EE_Form_Section_Base
+     * @throws EE_Error
+     */
+    public function consentBox(): EE_Form_Section_Base
+    {
+        return new EE_Form_Section_Proper([
+            'layout_strategy' => new EE_Div_Per_Section_Layout(),
+            'subsections' => [
+                'consent' => new EE_Checkbox_Multi_Input(
+                    [
+                        'consent' => esc_html__(
+                            'Allow Square to store my contact information.',
+                            'event_espresso'
+                        ),
+                    ],
+                    [
+                        'required' => true,
+                        'required_validation_error_message' => esc_html__(
+                            'You must consent to these terms in order to proceed with the registration.',
+                            'event_espresso'
+                        ),
+                        'html_label_text' => '',
+                    ]
+                ),
+            ]
         ]);
     }
 

--- a/payment_methods/SquareOnsite/forms/BillingForm.php
+++ b/payment_methods/SquareOnsite/forms/BillingForm.php
@@ -189,9 +189,9 @@ class BillingForm extends EE_Billing_Attendee_Info_Form
                         ),
                     ],
                     [
-                        'required' => true,
+                        'required' => false,
                         'required_validation_error_message' => esc_html__(
-                            'You must consent to these terms in order to proceed with the registration.',
+                            'This will allow Square to store your billing information as a Client entity.',
                             'event_espresso'
                         ),
                         'html_label_text' => '',

--- a/payment_methods/SquareOnsite/help_tabs/pm_overview_square.help_tab.php
+++ b/payment_methods/SquareOnsite/help_tabs/pm_overview_square.help_tab.php
@@ -49,6 +49,12 @@
             <li>
                 <?php esc_html_e('Read my merchant profile information', 'event_espresso'); ?>
             </li>
+            <li>
+                <?php esc_html_e('Read my customer contact information', 'event_espresso'); ?>
+            </li>
+            <li>
+                <?php esc_html_e('Modify my customer contact information', 'event_espresso'); ?>
+            </li>
         </ul>
     </li>
     <li>

--- a/payment_methods/SquareOnsite/templates/squareConsentBox.template.php
+++ b/payment_methods/SquareOnsite/templates/squareConsentBox.template.php
@@ -1,0 +1,7 @@
+<?php if (! defined('EVENT_ESPRESSO_VERSION')) {
+    exit('No direct script access allowed');
+} ?>
+
+<div class="eea-square-privacy-consent-assertion">
+    <?php echo $input->get_html_for_input(); // already escaped ?>
+</div>


### PR DESCRIPTION
Resolves #24

This adds Customers API support.
On every new registrations and Payment with Square, this plugin now also creates Customers based on the primary registrant information, and associates them with the payment. This also makes sure that the customer doesn't exist before creating one.

**Testing:**
* [x] OAuth (Connect) using the `master` branch of this add-on. Register for a non free event paying by using Square. There should be no errors with the checkout.
* [x] Checkout this branch. Re-OAuth (reconnect). Checkout using Square. Check the square dashboard and make sure [new customers](https://squareupsandbox.com/dashboard/customers) are being created.
* [ ] Check if [transactions have the association](https://squareupsandbox.com/dashboard/sales/transactions) with the customers. i.e. customer information in them.