### PR TITLE
Enhance logging and don't try to verify the domain when the settings page is opened if the domain is already verified.

### DIFF
--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -842,7 +842,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
         $sensitive_data = ['access_token', 'refresh_token', 'nonce'];
         foreach ($data as $key => $value) {
             $value = is_array($value) ? EED_SquareOnsiteOAuth::cleanDataArray($value) : $value;
-            if(in_array($key, $sensitive_data)) {
+            if (in_array($key, $sensitive_data)) {
                 $data[$key] = empty($value) ? '**empty**' : '**hidden**';
             }
         }

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -723,7 +723,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
             // Throttle the requests a bit.
             $now = new DateTime('now');
             $squareData = $squarePm->get_extra_meta(Domain::META_KEY_SQUARE_DATA, true);
-            if (isset($squareData[ Domain::META_KEY_THROTTLE_TIME ]) && $squareData[ Domain::META_KEY_THROTTLE_TIME ]) {
+            if (!empty($squareData[ Domain::META_KEY_THROTTLE_TIME ])) {
                 $throttleTime = new DateTime($squareData[ Domain::META_KEY_THROTTLE_TIME ]);
                 $lastChecked = $now->diff($throttleTime)->format('%a');
                 // Throttle, allowing only once per 2 days.
@@ -735,7 +735,7 @@ class EED_SquareOnsiteOAuth extends EED_Module
             $squarePm->update_extra_meta(Domain::META_KEY_SQUARE_DATA, $squareData);
 
             // Now check the token's validation date.
-            if (isset($squareData[ Domain::META_KEY_EXPIRES_AT ]) && $squareData[ Domain::META_KEY_EXPIRES_AT ]) {
+            if (!empty($squareData[ Domain::META_KEY_EXPIRES_AT ])) {
                 $expiresAt = new DateTime($squareData[ Domain::META_KEY_EXPIRES_AT ]);
                 $timeLeft = $now->diff($expiresAt);
                 $daysLeft = $timeLeft->format('%a');

--- a/modules/EED_SquareOnsiteOAuth.module.php
+++ b/modules/EED_SquareOnsiteOAuth.module.php
@@ -842,7 +842,9 @@ class EED_SquareOnsiteOAuth extends EED_Module
         $sensitive_data = ['access_token', 'refresh_token', 'nonce'];
         foreach ($data as $key => $value) {
             $value = is_array($value) ? EED_SquareOnsiteOAuth::cleanDataArray($value) : $value;
-            $data[ $key ] = in_array($key, $sensitive_data) ? '***' : $value;
+            if(in_array($key, $sensitive_data)) {
+                $data[$key] = empty($value) ? '**empty**' : '**hidden**';
+            }
         }
         return $data;
     }

--- a/payment_methods/SquareOnsite/forms/SettingsForm.php
+++ b/payment_methods/SquareOnsite/forms/SettingsForm.php
@@ -416,11 +416,16 @@ class SettingsForm extends EE_Payment_Method_Form
     private function registerBlogDomain(EE_Payment_Method $pmInstance)
     {
         try {
-            $response = EED_SquareOnsiteOAuth::registerDomain($pmInstance);
-            if (! empty($response['status'])) {
-                // save the status
-                $this->squareData[ Domain::META_KEY_DOMAIN_VERIFY ] = $response['status'];
-                $pmInstance->update_extra_meta(Domain::META_KEY_SQUARE_DATA, $this->squareData);
+            if (
+                empty($this->squareData[ Domain::META_KEY_DOMAIN_VERIFY ])
+                || $this->squareData[ Domain::META_KEY_DOMAIN_VERIFY ] !== 'VERIFIED'
+            ){
+                $response = EED_SquareOnsiteOAuth::registerDomain($pmInstance);
+                if (! empty($response['status'])) {
+                    // save the status
+                    $this->squareData[ Domain::META_KEY_DOMAIN_VERIFY ] = $response['status'];
+                    $pmInstance->update_extra_meta(Domain::META_KEY_SQUARE_DATA, $this->squareData);
+                }
             }
         } catch (EE_Error | ReflectionException $e) {
             // No action required here in this case.


### PR DESCRIPTION
Each time the square payment method setting page was loaded it tried to verify the domain even if it was already verified, so I've added a check to only do it automatically if the domain is not set to 'verified' already.

Also, when logging 'sensitive' data for the oAuth requests it would swap out the values to be just `***` but we need to know if the values are empty, or hidden so I've added a check for that so the log entry will now show `**empty**` or `**hidden**` (I need to know if keys are on the request so, can't just skip them when empty for example.


## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
