### PR TITLE
Select the correct input type

### DIFF
--- a/assets/js/square-payments.js
+++ b/assets/js/square-payments.js
@@ -152,9 +152,9 @@ jQuery(document).ready(function($) {
 				this.billCity = this.billingForm.find(
 					'input[id*="billing-form-city"]:visible');
 				this.billState = this.billingForm.find(
-					'input[id*="billing-form-state"]:visible');
+					'select[id*="billing-form-state"]:visible');
 				this.billCountry = this.billingForm.find(
-					'input[id*="billing-form-country"]:visible');
+					'select[id*="billing-form-country"]:visible');
 				this.billZip = this.billingForm.find(
 					'input[id*="billing-form-zip"]:visible');
 				this.billPhone = this.billingForm.find(


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
Fixes the element selector, where it was trying to find a country input which was really a `select`.

Should fix the:
```
Unhandled Promise Rejection: TypeError: "" is not a valid country code.
```

## How has this been tested
In some cases, while trying to checkout with Apple or Google pay it was throwing an error.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
